### PR TITLE
Replace the equality test implementation of the public keys based on SHA...

### DIFF
--- a/server/src/main/java/org/kercoin/magrit/sshd/GitPublickeyAuthenticator.java
+++ b/server/src/main/java/org/kercoin/magrit/sshd/GitPublickeyAuthenticator.java
@@ -71,23 +71,9 @@ public class GitPublickeyAuthenticator implements PublickeyAuthenticator {
 	}
 	
 	boolean areEqual(PublicKey ref, PublicKey candidate) {
-		byte[] raw = sha1(candidate.getEncoded());
-		byte[] target = sha1(ref.getEncoded());
-		return Arrays.areEqual(target, raw);
+		return Arrays.areEqual(ref.getEncoded(), candidate.getEncoded());
 	}
-	
-	byte[] sha1(byte[] data) {
-		try {
-			Digest digest = new SHA1.Factory().create();
-			digest.init();
-			digest.update(data, 0, data.length);
-			return digest.digest();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-		return new byte[20];
-	}
-	
+		
 	private PublicKey readKeyFromRepository(String username) throws AmbiguousObjectException, Exception {
 		String revstr = String.format("HEAD:keys/%s.pub", username);
 		String encoded = gitUtils.show(datasource, revstr);


### PR DESCRIPTION
...-1 by a more classical, simple, faster and secure one based on Arrays.areEqual(byte[], byte[]).

In addition to the fact that an hashing function is not required for this purpose, please note that the usage of the SHA-1 algorithm is no more recommanded for security purpose from 2005 because it is broken/cracked (http://www.schneier.com/blog/archives/2005/02/sha1_broken.html). Instead, it is recommanded to use SHA-256.
